### PR TITLE
fix crash after adding or deleting a friend

### DIFF
--- a/src/liblwqq/info.c
+++ b/src/liblwqq/info.c
@@ -1634,7 +1634,7 @@ static int info_commom_back(LwqqHttpRequest* req,void* data)
     }
     errno = s_atoi(retcode);
     void** d = data;
-    long type = (long)d[0];
+    long type = data ? (long)d[0] : 0;
     if(errno==0&&data!=NULL){
         switch(type){
             case CHANGE_BUDDY_MARKNAME:


### PR DESCRIPTION
When a request is made with no callback argument data,
there will be a segfault.

One origin of the request is:
lwqq_info_allow_and_add() at the line:
return req->do_request_async(req,1,post,_C_(2p_i,info_commom_back,req,NULL));
