### PR TITLE
cmake: Add zlib dependency to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ pkg_check_modules(PURPLE REQUIRED  purple)
 pkg_check_modules(GLIB REQUIRED  glib-2.0)
 pkg_check_modules(CURL REQUIRED libcurl)
 pkg_check_modules(SQLITE REQUIRED sqlite3)
+pkg_check_modules(ZLIB REQUIRED zlib)
 #recommand libcurl>=7.22.0
 
 add_definitions(-Wall)


### PR DESCRIPTION
When building on fedora-18 xfce, it does not
prompt a warning that I don't have zlib-devel.

But it will appear at make: can't find zlib.h.
